### PR TITLE
add default environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN dpkg --add-architecture i386 && \
 ENV PATH="$PATH:/usr/games"
 ENV UsePerfThreads=true
 ENV NoAsyncLoadingThread=true
+ENV AutoUpdate=true
 
 WORKDIR /steamcmd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN dpkg --add-architecture i386 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH="$PATH:/usr/games"
+ENV UsePerfThreads=true
+ENV NoAsyncLoadingThread=true
 
 WORKDIR /steamcmd
 


### PR DESCRIPTION
If not set, the startup script fails with an unbound variable error for NoAsyncLoadingThread and UsePerfThreads. The simplest fix for this is to set these variables in the docker file so that they're always defined, even when no environment variables have been provided by the user.